### PR TITLE
Updated fort to support bastion v0.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ proc-macro2 = { version = "1.0.5", features = ["nightly"] }
 quote = "1.0.2"
 
 [dev-dependencies]
-bastion = "0.2"
+bastion = "0.3"
 
 [profile.dev]
 panic = "unwind"

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -1,5 +1,7 @@
-#[fort::root]
-fn main() {
+use bastion::prelude::*;
+
+#[fort::root(redundancy = 10)]
+async fn main(_: BastionContext) -> Result<(), ()> {
     loop {
         println!("Undying main!");
         panic!("Error")

--- a/examples/redundancy.rs
+++ b/examples/redundancy.rs
@@ -1,4 +1,7 @@
+use bastion::prelude::*;
+
 #[fort::root(redundancy = 2)]
-fn main() {
+async fn main(_: BastionContext) -> Result<(), ()> {
     println!("Apply redundancy, default is 1");
+    Ok(())
 }

--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -1,8 +1,9 @@
+use bastion::prelude::*;
 use std::io::Write;
 use std::net::TcpListener;
 
 #[fort::root]
-fn main() {
+async fn main(_: BastionContext) -> Result<(), ()> {
     let listener = TcpListener::bind("127.0.0.1:2278").unwrap();
     println!("TCP server started at 127.0.0.1:2278");
     for stream in listener.incoming() {
@@ -10,4 +11,6 @@ fn main() {
         stream.write(b"Hello World\r\n").unwrap();
         panic!("Fail here!");
     }
+
+    Ok(())
 }

--- a/examples/threaded_tcp_server.rs
+++ b/examples/threaded_tcp_server.rs
@@ -1,17 +1,20 @@
+use bastion::prelude::*;
 use std::io::Write;
 use std::net::TcpListener;
 use std::thread;
 
 #[fort::root]
-fn main() {
+async fn main(_: BastionContext) -> Result<(), ()> {
     let listener = TcpListener::bind("127.0.0.1:2278").unwrap();
     println!("TCP server started at 127.0.0.1:2278");
     for stream in listener.incoming() {
         thread::spawn(|| {
             let mut stream = stream.unwrap();
-            stream.write(b"Hello World\r\n").unwrap();
+            stream.write_all(b"Hello World\r\n").unwrap();
             panic!("Fail in thread!");
         });
         panic!("Fail in event loop");
     }
+
+    Ok(())
 }


### PR DESCRIPTION
Hey :wave:!

I updated `fort` to support `bastion` v0.3, including asking for the function marked with `#[fort::root]` (currently only `main` is supported) to be declared as `async`, to have only one argument, of type `BastionContext`, and have `Result<(), ()>` as its return type.

Currently, the type of the argument isn't checked by the macro (only that the function is declared with exactly one) and neither is the return type (again, it only checks that there is a return type declared), though, the compiler will enforce this because the macro uses them to declare the `exec` future.

Cheers!